### PR TITLE
GET com verificação se usuário deu like/Eu vou ou não 

### DIFF
--- a/apps/api/src/__tests__/post/post.controller.test.ts
+++ b/apps/api/src/__tests__/post/post.controller.test.ts
@@ -31,6 +31,7 @@ describe("PostController", () => {
   describe("listPosts", () => {
     it("deve retornar 400 se limit > 50", async () => {
       req = {
+        body: { userId: "1" },
         query: { limit: "100", page: "1" },
       };
 
@@ -50,11 +51,10 @@ describe("PostController", () => {
 
       (postService.listPosts as jest.Mock).mockResolvedValue(mockResult);
 
-      req = { query: { limit: "10", page: "1" } };
-
+      req = { body: { userId: "1" }, query: { limit: "10", page: "1" } };
       await postController.listPosts(req as Request, res as Response);
 
-      expect(postService.listPosts).toHaveBeenCalledWith(10, 1);
+      expect(postService.listPosts).toHaveBeenCalledWith(10, 1, "1");
       expect(res.status).toHaveBeenCalledWith(httpStatus.OK);
       expect(res.json).toHaveBeenCalledWith(mockResult);
 
@@ -64,11 +64,11 @@ describe("PostController", () => {
       const mockResult = { page: 1, limit: 10, items: [] };
       (postService.listPosts as jest.Mock).mockResolvedValue(mockResult);
 
-      req = { query: { limit: "abc", page: "zzz" } };
+      req = { body: { userId: "1" }, query: { limit: "abc", page: "zzz" } };
 
       await postController.listPosts(req as Request, res as Response);
 
-      expect(postService.listPosts).toHaveBeenCalledWith(10, 1);
+      expect(postService.listPosts).toHaveBeenCalledWith(10, 1, "1");
       expect(res.status).toHaveBeenCalledWith(httpStatus.OK);
     });
   });

--- a/apps/api/src/modules/post/post.controller.ts
+++ b/apps/api/src/modules/post/post.controller.ts
@@ -5,6 +5,10 @@ import { ApiError } from "../../utils/ApiError";
 
 class PostController {
   async listPosts(req: Request, res: Response) {
+    if(!req.body.userId){
+      throw new ApiError(httpStatus.BAD_REQUEST, "UserId é obrigatório no corpo da requisição");
+    }
+
     const DEFAULT_PAGE_LIMIT = 10;
     const DEFAULT_PAGE = 1;
 
@@ -13,7 +17,7 @@ class PostController {
 
     const safeLimit = isNaN(limit) ? DEFAULT_PAGE_LIMIT : limit;
     const safePage = isNaN(page) ? DEFAULT_PAGE : page;
-    
+
     if (safeLimit > 50) {
       throw new ApiError(
         httpStatus.BAD_REQUEST,
@@ -23,6 +27,7 @@ class PostController {
     const paginatedResult = await postService.listPosts(
       safeLimit,
       safePage,
+      req.body.userId,
     );
     res.status(httpStatus.OK).json(paginatedResult);
   }

--- a/apps/api/src/modules/post/post.service.ts
+++ b/apps/api/src/modules/post/post.service.ts
@@ -4,12 +4,13 @@ import { ApiError } from "../../utils/ApiError";
 import httpStatus from "http-status";
 
 export const postService = {
-  listPosts: async (limit: number, page: number) => {
+  listPosts: async (limit: number, page: number, userId: string) => {
     const offset = limit && page ? (page - 1) * limit : 0;
 
     const { posts, totalCount } = await postRepository.findAll(
       limit,
       offset,
+      userId,
     );
 
     const totalPages = Math.ceil(totalCount / limit);

--- a/apps/api/src/modules/post/post.validation.ts
+++ b/apps/api/src/modules/post/post.validation.ts
@@ -14,6 +14,9 @@ export const listPostsSchema = z.object({
       .optional(),
     page: z.coerce.number().int().positive().default(PAGE).optional(),
   }),
+  body: z.object({
+    userId: z.uuid(),
+  }),
 });
 
 export const createPostSchema = z.object({


### PR DESCRIPTION
## 🔎 **Qual o objetivo desse PR?**
- **Motivação:** O frontend precisa para cada objeto de Post na resposta do backend de campos dizendo se o usuário deu like ou não, se o usuário marcou presença ou não
- **Solução:** Adiciona campos booleanos nos objetos da resposta.

---
## 💡 **Issues relacionadas**

Closes #34
---

## ✨ **Tipo de alteração**
- [ ] 🐞 Correção de bug ***(bug-fix)***
- [X] ✨ Nova funcionalidade ***(feature)***
- [ ] 🔨 Melhoria no código ou refatoração ***(refactor)***
- [ ] 📖 Alteração na documentação ***(docs)***
- [ ] 🚧 Mudança de infraestrutura ou CI/CD ***(chore)***
- [ ] 🧪 Adição ou melhoria de testes ***(tests)***

---
## ❓ **Como isso foi testado?**
1. **Passos para reproduzir:**
    - `git checkout feat/34-feed-eventos-reader-backend`
    - `pnpm install`
    - `pnpm dev:api`
    -  ou 
    -`pnpm test:api`

2. **Cenários de teste:**
    - [X] Teste de **fluxo correto do usuário**.
    - [X] Teste com **dados inválidos**. (ex: formulário com e-mail incorreto).

---

## ✅ Checklist de Qualidade
- [X] Meu código segue as **diretrizes de estilo** do projeto.
- [X] Eu realizei a **auto-revisão (self-review)** do meu próprio código.
- [X] Eu **comentei as partes mais complexas do código**.
- [X] Eu adicionei **testes que provam minha correção é eficaz ou que minha feature funciona**.
- [X] Minhas alterações **não geram novos warnings ou erros** no console.
- [X] A **documentação relevante foi atualizada** (se necessário).

---